### PR TITLE
Replace blocking serial port methods with asynchronous versions.

### DIFF
--- a/Source/ArduinoDriver.Samples.SMBTune/Program.cs
+++ b/Source/ArduinoDriver.Samples.SMBTune/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using System.Threading.Tasks;
 using ArduinoDriver.SerialProtocol;
 using ArduinoUploader.Hardware;
 
@@ -58,17 +59,21 @@ namespace ArduinoDriver.Samples.SMBTune
 
         private static void Main(string[] args)
         {
+            MainAsync(args).GetAwaiter().GetResult();
+        }
+
+        private static async Task MainAsync(string[] args)
+        {
             using (var driver = new ArduinoDriver(AttachedArduino, true))
             {
                 for (var i = 0; i < melody.Length; i++)
                 {
                     var noteDuration = 1000 / tempo[i];
-                    driver.Send(new ToneRequest(DigitalPinBuzzer, (ushort)melody[i], (uint)noteDuration));
+                    await driver.SendAsync(new ToneRequest(DigitalPinBuzzer, (ushort)melody[i], (uint)noteDuration));
                     Thread.Sleep((int)(noteDuration * 1.40));
-                    driver.Send(new NoToneRequest(DigitalPinBuzzer));
+                    await driver.SendAsync(new NoToneRequest(DigitalPinBuzzer));
                 }
             }
-
         }
     }
 }

--- a/Source/ArduinoDriver.Samples.SMBTune/Program.cs
+++ b/Source/ArduinoDriver.Samples.SMBTune/Program.cs
@@ -64,7 +64,7 @@ namespace ArduinoDriver.Samples.SMBTune
 
         private static async Task MainAsync(string[] args)
         {
-            using (var driver = new ArduinoDriver(AttachedArduino, true))
+            using (var driver = await ArduinoDriver.CreateAsync(AttachedArduino, true))
             {
                 for (var i = 0; i < melody.Length; i++)
                 {

--- a/Source/ArduinoDriver/ArduinoDriver.cs
+++ b/Source/ArduinoDriver/ArduinoDriver.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using ArduinoDriver.SerialEngines;
 using ArduinoDriver.SerialProtocol;
 using ArduinoUploader;
@@ -96,9 +97,9 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="request">Analog Read Request</param>
         /// <returns>The Analog Read Response</returns>
-        public AnalogReadResponse Send(AnalogReadRequest request)
+        public async Task<AnalogReadResponse> SendAsync(AnalogReadRequest request)
         {
-            return (AnalogReadResponse) InternalSend(request);
+            return (AnalogReadResponse) await InternalSendAsync(request);
         }
 
         /// <summary>
@@ -106,9 +107,9 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="request">Analog Write Request</param>
         /// <returns>The Analog Write Response</returns>
-        public AnalogWriteResponse Send(AnalogWriteRequest request)
+        public async Task<AnalogWriteResponse> SendAsync(AnalogWriteRequest request)
         {
-            return (AnalogWriteResponse) InternalSend(request);
+            return (AnalogWriteResponse) await InternalSendAsync(request);
         }
 
         /// <summary>
@@ -116,9 +117,9 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="request">Digital Read Request</param>
         /// <returns>The Digital Read Response</returns>
-        public DigitalReadResponse Send(DigitalReadRequest request)
+        public async Task<DigitalReadResponse> SendAsync(DigitalReadRequest request)
         {
-            return (DigitalReadResponse) InternalSend(request);
+            return (DigitalReadResponse) await InternalSendAsync(request);
         }
 
         /// <summary>
@@ -126,9 +127,9 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="request">Digital Write Request</param>
         /// <returns>The Digital Write Response</returns>
-        public DigitalWriteReponse Send(DigitalWriteRequest request)
+        public async Task<DigitalWriteReponse> SendAsync(DigitalWriteRequest request)
         {
-            return (DigitalWriteReponse) InternalSend(request);
+            return (DigitalWriteReponse) await InternalSendAsync(request);
         }
 
         /// <summary>
@@ -136,9 +137,9 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="request">PinMode Request</param>
         /// <returns>The PinMode Response</returns>
-        public PinModeResponse Send(PinModeRequest request)
+        public async Task<PinModeResponse> SendAsync(PinModeRequest request)
         {
-            return (PinModeResponse) InternalSend(request);
+            return (PinModeResponse) await InternalSendAsync(request);
         }
 
         /// <summary>
@@ -146,9 +147,9 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="request">Tone Request</param>
         /// <returns>The Tone Response</returns>
-        public ToneResponse Send(ToneRequest request)
+        public async Task<ToneResponse> SendAsync(ToneRequest request)
         {
-            return (ToneResponse) InternalSend(request);
+            return (ToneResponse) await InternalSendAsync(request);
         }
 
         /// <summary>
@@ -156,9 +157,9 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="request">NoTone Request</param>
         /// <returns>The NoTone Response</returns>
-        public NoToneResponse Send(NoToneRequest request)
+        public async Task<NoToneResponse> SendAsync(NoToneRequest request)
         {
-            return (NoToneResponse) InternalSend(request);
+            return (NoToneResponse) await InternalSendAsync(request);
         }
 
         /// <summary>
@@ -166,9 +167,9 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="request">AnalogReference Request</param>
         /// <returns>AnalogReference Response</returns>
-        public AnalogReferenceResponse Send(AnalogReferenceRequest request)
+        public async Task<AnalogReferenceResponse> SendAsync(AnalogReferenceRequest request)
         {
-            return (AnalogReferenceResponse) InternalSend(request);
+            return (AnalogReferenceResponse) await InternalSendAsync(request);
         }
 
         /// <summary>
@@ -176,9 +177,9 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="request">ShiftOut Request</param>
         /// <returns>ShiftOut Response</returns>
-        public ShiftOutResponse Send(ShiftOutRequest request)
+        public async Task<ShiftOutResponse> SendAsync(ShiftOutRequest request)
         {
-            return (ShiftOutResponse) InternalSend(request);
+            return (ShiftOutResponse) await InternalSendAsync(request);
         }
 
         /// <summary>
@@ -186,9 +187,9 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
-        public ShiftInResponse Send(ShiftInRequest request)
+        public async Task<ShiftInResponse> SendAsync(ShiftInRequest request)
         {
-            return (ShiftInResponse) InternalSend(request);
+            return (ShiftInResponse) await InternalSendAsync(request);
         }
 
         /// <summary>
@@ -209,7 +210,7 @@ namespace ArduinoDriver
 
         #region Private Methods
 
-        private void Initialize(ArduinoDriverConfiguration config)
+        private Task Initialize(ArduinoDriverConfiguration config)
         {
             logger.Info("Instantiating ArduinoDriver: {0} - {1}...", config.ArduinoModel, config.PortName);
 
@@ -229,17 +230,18 @@ namespace ArduinoDriver
                 }
             }
 
-            if (!config.AutoBootstrap) InitializeWithoutAutoBootstrap();
-            else InitializeWithAutoBootstrap();
+            return config.AutoBootstrap
+                ? InitializeWithAutoBootstrapAsync()
+                : InitializeWithoutAutoBootstrapAsync();
         }
 
-        private void InitializeWithoutAutoBootstrap()
+        private async Task InitializeWithoutAutoBootstrapAsync()
         {
             // Without auto bootstrap, we just try to send a handshake request (the listener should already be
             // deployed). If that fails, we try nothing else.
             logger.Info("Initiating handshake...");
             InitializePort();
-            var handshakeResponse = ExecuteHandshake();
+            var handshakeResponse = await ExecuteHandshakeAsync();
             if (handshakeResponse == null)
             {
                 port.Close();
@@ -254,7 +256,7 @@ namespace ArduinoDriver
             }
         }
 
-        private void InitializeWithAutoBootstrap()
+        private async Task InitializeWithAutoBootstrapAsync()
         {
             var alwaysReDeployListener = alwaysRedeployListeners.Count > 500;
             HandShakeResponse handshakeResponse = null;
@@ -264,7 +266,7 @@ namespace ArduinoDriver
             {
                 logger.Info("Initiating handshake...");
                 InitializePort();
-                handshakeResponse = ExecuteHandshake();
+                handshakeResponse = await ExecuteHandshakeAsync();
                 handShakeAckReceived = handshakeResponse != null;
                 if (handShakeAckReceived)
                 {
@@ -313,7 +315,7 @@ namespace ArduinoDriver
 
             // Listener should now (always) be deployed, handshake should yield success.
             InitializePort();
-            handshakeResponse = ExecuteHandshake();
+            handshakeResponse = await ExecuteHandshakeAsync();
             if (handshakeResponse == null)
                 throw new IOException("Unable to get a handshake ACK after executing auto bootstrap on the Arduino!");  
             logger.Info("ArduinoDriver fully initialized!");      
@@ -331,14 +333,14 @@ namespace ArduinoDriver
             port.Open();
         }
 
-        private ArduinoResponse InternalSend(ArduinoRequest request)
+        private Task<ArduinoResponse> InternalSendAsync(ArduinoRequest request)
         {
-            return port.Send(request);
+            return port.SendAsync(request);
         }
 
-        private HandShakeResponse ExecuteHandshake()
+        private async Task<HandShakeResponse> ExecuteHandshakeAsync()
         {
-            var response = port.Send(new HandShakeRequest(), 1);
+            var response = await port.SendAsync(new HandShakeRequest(), 1);
             return response as HandShakeResponse;            
         }
 

--- a/Source/ArduinoDriver/ArduinoDriver.cs
+++ b/Source/ArduinoDriver/ArduinoDriver.cs
@@ -42,12 +42,15 @@ namespace ArduinoDriver
         private const string ArduinoListenerHexResourceFileName =
             "ArduinoDriver.ArduinoListener.ArduinoListener.ino.{0}.hex";
 
+        private ArduinoDriver()
+        { }
+
         /// <summary>
         /// Creates a new ArduinoDriver instance. The relevant portname will be autodetected if possible.
         /// </summary>
         /// <param name="arduinoModel"></param>
         /// <param name="autoBootstrap"></param>
-        public ArduinoDriver(ArduinoModel arduinoModel, bool autoBootstrap = false)
+        public static async Task<ArduinoDriver> CreateAsync(ArduinoModel arduinoModel, bool autoBootstrap = false)
         {
             logger.Info(
                 "Instantiating ArduinoDriver (model {0}) with autoconfiguration of port name...",
@@ -68,12 +71,14 @@ namespace ArduinoDriver
                     "Unable to autoconfigure ArduinoDriver port name, since there is not exactly a single "
                     + "COM port available. Please use the ArduinoDriver with the named port constructor!");
 
-            Initialize(new ArduinoDriverConfiguration
+            var arduinoDriver = new ArduinoDriver();
+            await arduinoDriver.InitializeAsync(new ArduinoDriverConfiguration
             {
                 ArduinoModel = arduinoModel, 
                 PortName = unambiguousPortName, 
                 AutoBootstrap = autoBootstrap
             });
+            return arduinoDriver;
         }
 
         /// <summary>
@@ -81,15 +86,17 @@ namespace ArduinoDriver
         /// </summary>
         /// <param name="arduinoModel"></param>
         /// <param name="portName">The COM portname to create the ArduinoDriver instance for.</param>
-        /// <param name="autoBootStrap">Determines if an listener is automatically deployed to the Arduino if required.</param>
-        public ArduinoDriver(ArduinoModel arduinoModel, string portName, bool autoBootstrap = false)
+        /// <param name="autoBootstrap">Determines if an listener is automatically deployed to the Arduino if required.</param>
+        public static async Task<ArduinoDriver> CreateAsync(ArduinoModel arduinoModel, string portName, bool autoBootstrap = false)
         {
-            Initialize(new ArduinoDriverConfiguration
+            var arduinoDriver = new ArduinoDriver();
+            await arduinoDriver.InitializeAsync(new ArduinoDriverConfiguration
             {
                 ArduinoModel = arduinoModel,
                 PortName = portName,
                 AutoBootstrap = autoBootstrap
             });
+            return arduinoDriver;
         }
 
         /// <summary>
@@ -210,7 +217,7 @@ namespace ArduinoDriver
 
         #region Private Methods
 
-        private Task Initialize(ArduinoDriverConfiguration config)
+        private Task InitializeAsync(ArduinoDriverConfiguration config)
         {
             logger.Info("Instantiating ArduinoDriver: {0} - {1}...", config.ArduinoModel, config.PortName);
 

--- a/Source/ArduinoDriver/SerialEngines/DefaultSerialPort.cs
+++ b/Source/ArduinoDriver/SerialEngines/DefaultSerialPort.cs
@@ -1,8 +1,18 @@
 ﻿using System.IO.Ports;
+using System.Threading.Tasks;
 
 namespace ArduinoDriver.SerialEngines
 {
     public class DefaultSerialPort : SerialPort, ISerialPortEngine
     {
+        Task ISerialPortEngine.WriteAsync(byte[] buffer, int offset, int count)
+        {
+            return BaseStream.WriteAsync(buffer, offset, count);
+        }
+
+        Task<int> ISerialPortEngine.ReadAsync(byte[] buffer, int offset, int count)
+        {
+            return BaseStream.ReadAsync(buffer, offset, count);
+        }
     }
 }

--- a/Source/ArduinoDriver/SerialEngines/ISerialPortEngine.cs
+++ b/Source/ArduinoDriver/SerialEngines/ISerialPortEngine.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace ArduinoDriver.SerialEngines
 {
@@ -10,7 +11,7 @@ namespace ArduinoDriver.SerialEngines
         int WriteTimeout { get; set; }
         void Open();
         void Close();
-        void Write(byte[] buffer, int offset, int count);
-        int Read(byte[] buffer, int offset, int count);
+        Task WriteAsync(byte[] buffer, int offset, int count);
+        Task<int> ReadAsync(byte[] buffer, int offset, int count);
     }
 }


### PR DESCRIPTION
With non-blocking requests it's much easier to use this library in desktop (e.g. WinForm and WPF) projects.
Asynchronous methods allows users of ArduinoDriver to take full advantages of async/await methods with cancellation and automatic capturing of synchronization context.
Now users of this library can create long running PC-to-Arduino communication workflows without freezing UI.
Also now it's easier to concurrently communicate with a couple of Arduino boards using Task.WhenAll, Task.WhenAny methods.